### PR TITLE
Update OPENWRT_GIT web address

### DIFF
--- a/include/download.mk
+++ b/include/download.mk
@@ -5,7 +5,7 @@
 # See /LICENSE for more information.
 #
 
-OPENWRT_GIT = http://git.openwrt.org
+OPENWRT_GIT = https://git.archive.openwrt.org
 
 DOWNLOAD_RDEP=$(STAMP_PREPARED) $(HOST_STAMP_PREPARED)
 


### PR DESCRIPTION
This should solve "fatal: repository 'http://git.openwrt.org/project/fstools.git/' not found" and similar problems.