### PR TITLE
ar71xx: Add support for TP-LINK TL-WR842N/ND v3 to OpenWrt Chaos Calmer 15.05.

### DIFF
--- a/target/linux/ar71xx/base-files/etc/diag.sh
+++ b/target/linux/ar71xx/base-files/etc/diag.sh
@@ -280,6 +280,7 @@ get_status_led() {
 	tl-wr841n-v11 | \
 	tl-wa830re-v2 | \
 	tl-wr842n-v2 | \
+	tl-wr842n-v3 | \
 	tl-wr941nd | \
 	tl-wr941nd-v5)
 		status_led="tp-link:green:system"

--- a/target/linux/ar71xx/base-files/etc/uci-defaults/01_leds
+++ b/target/linux/ar71xx/base-files/etc/uci-defaults/01_leds
@@ -519,6 +519,16 @@ tl-wr842n-v2)
 	ucidef_set_led_usbdev "usb" "USB" "tp-link:green:3g" "1-1"
 	;;
 
+tl-wr842n-v3)
+	ucidef_set_led_netdev "wan" "WAN" "tp-link:green:wan" "eth1"
+	ucidef_set_led_switch "lan1" "LAN1" "tp-link:green:lan1" "switch0" "0x10"
+	ucidef_set_led_switch "lan2" "LAN2" "tp-link:green:lan2" "switch0" "0x08"
+	ucidef_set_led_switch "lan3" "LAN3" "tp-link:green:lan3" "switch0" "0x04"
+	ucidef_set_led_switch "lan4" "LAN4" "tp-link:green:lan4" "switch0" "0x02"
+	ucidef_set_led_wlan "wlan" "WLAN" "tp-link:green:wlan" "phy0tpt"
+	ucidef_set_led_usbdev "usb" "USB" "tp-link:green:3g" "1-1"
+	;;
+
 tl-wa801nd-v2 | \
 tl-wa901nd-v3)
 	ucidef_set_led_netdev "lan" "LAN" "tp-link:green:lan" "eth0"

--- a/target/linux/ar71xx/base-files/etc/uci-defaults/02_network
+++ b/target/linux/ar71xx/base-files/etc/uci-defaults/02_network
@@ -440,6 +440,7 @@ tl-wr741nd-v4 |\
 tl-wr841n-v7 |\
 tl-wr841n-v9 |\
 tl-wr841n-v11 |\
+tl-wr842n-v3 |\
 whr-g301n |\
 whr-hp-g300n |\
 whr-hp-gn |\

--- a/target/linux/ar71xx/base-files/lib/ar71xx.sh
+++ b/target/linux/ar71xx/base-files/lib/ar71xx.sh
@@ -821,6 +821,9 @@ ar71xx_board_detect() {
 	*"TL-WR842N/ND v2")
 		name="tl-wr842n-v2"
 		;;
+	*"TL-WR842N/ND v3")
+		name="tl-wr842n-v3"
+		;;
 	*TL-WR941ND)
 		name="tl-wr941nd"
 		;;

--- a/target/linux/ar71xx/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ar71xx/base-files/lib/upgrade/platform.sh
@@ -361,6 +361,7 @@ platform_check_image() {
 	tl-wr841n-v9 | \
 	tl-wr841n-v11 | \
 	tl-wr842n-v2 | \
+	tl-wr842n-v3 | \
 	tl-wr941nd | \
 	tl-wr941nd-v5 | \
 	tl-wr941nd-v6 | \

--- a/target/linux/ar71xx/files/arch/mips/ath79/mach-tl-wr841n-v9.c
+++ b/target/linux/ar71xx/files/arch/mips/ath79/mach-tl-wr841n-v9.c
@@ -36,6 +36,20 @@
 #define TL_WR841NV9_GPIO_BTN_RESET	12
 #define TL_WR841NV9_GPIO_BTN_WIFI	17
 
+#define TL_WR842NV3_GPIO_LED_SYSTEM	2
+#define TL_WR842NV3_GPIO_LED_WLAN	3
+#define TL_WR842NV3_GPIO_LED_WAN_RED	4
+#define TL_WR842NV3_GPIO_LED_WAN_GREEN	11
+#define TL_WR842NV3_GPIO_LED_LAN1	12
+#define TL_WR842NV3_GPIO_LED_LAN2	13
+#define TL_WR842NV3_GPIO_LED_LAN3	14
+#define TL_WR842NV3_GPIO_LED_LAN4	15
+#define TL_WR842NV3_GPIO_LED_3G		16
+#define TL_WR842NV3_GPIO_LED_WPS	17
+
+#define TL_WR842NV3_GPIO_BTN_RESET	1
+#define TL_WR842NV3_GPIO_BTN_WIFI	0
+
 #define TL_WR841NV11_GPIO_LED_SYSTEM	1
 #define TL_WR841NV11_GPIO_LED_QSS	3
 #define TL_WR841NV11_GPIO_LED_WAN	4
@@ -151,6 +165,69 @@ static struct gpio_led tl_wr841n_v11_leds_gpio[] __initdata = {
 	},
 };
 
+static struct gpio_led tl_wr842n_v3_leds_gpio[] __initdata = {
+	{
+		.name		= "tp-link:green:lan1",
+		.gpio		= TL_WR842NV3_GPIO_LED_LAN1,
+		.active_low	= 1,
+	}, {
+		.name		= "tp-link:green:lan2",
+		.gpio		= TL_WR842NV3_GPIO_LED_LAN2,
+		.active_low	= 1,
+	}, {
+		.name		= "tp-link:green:lan3",
+		.gpio		= TL_WR842NV3_GPIO_LED_LAN3,
+		.active_low	= 1,
+	}, {
+		.name		= "tp-link:green:lan4",
+		.gpio		= TL_WR842NV3_GPIO_LED_LAN4,
+		.active_low	= 1,
+	}, {
+		.name		= "tp-link:green:wan",
+		.gpio		= TL_WR842NV3_GPIO_LED_WAN_GREEN,
+		.active_low	= 1,
+	}, {
+		.name		= "tp-link:red:wan",
+		.gpio		= TL_WR842NV3_GPIO_LED_WAN_RED,
+		.active_low	= 1,
+	}, {
+		.name		= "tp-link:green:wlan",
+		.gpio		= TL_WR842NV3_GPIO_LED_WLAN,
+		.active_low	= 1,
+	}, {
+		.name		= "tp-link:green:system",
+		.gpio		= TL_WR842NV3_GPIO_LED_SYSTEM,
+		.active_low	= 1,
+	}, {
+		.name		= "tp-link:green:3g",
+		.gpio		= TL_WR842NV3_GPIO_LED_3G,
+		.active_low	= 1,
+	}, {
+		.name		= "tp-link:green:wps",
+		.gpio		= TL_WR842NV3_GPIO_LED_WPS,
+		.active_low	= 1,
+	},
+};
+
+static struct gpio_keys_button tl_wr842n_v3_gpio_keys[] __initdata = {
+	{
+		.desc		= "Reset button",
+		.type		= EV_KEY,
+		.code		= KEY_RESTART,
+		.debounce_interval = TL_WR841NV9_KEYS_DEBOUNCE_INTERVAL,
+		.gpio		= TL_WR842NV3_GPIO_BTN_RESET,
+		.active_low	= 1,
+	}, {
+		.desc		= "WIFI button",
+		.type		= EV_KEY,
+		.code		= KEY_RFKILL,
+		.debounce_interval = TL_WR841NV9_KEYS_DEBOUNCE_INTERVAL,
+		.gpio		= TL_WR842NV3_GPIO_BTN_WIFI,
+		.active_low	= 1,
+	}
+};
+
+
 static void __init tl_ap143_setup(void)
 {
 	u8 *mac = (u8 *) KSEG1ADDR(0x1f01fc00);
@@ -197,6 +274,23 @@ static void __init tl_wr841n_v9_setup(void)
 
 MIPS_MACHINE(ATH79_MACH_TL_WR841N_V9, "TL-WR841N-v9", "TP-LINK TL-WR841N/ND v9",
 	     tl_wr841n_v9_setup);
+
+static void __init tl_wr842n_v3_setup(void)
+{
+	tl_ap143_setup();
+
+	ath79_register_leds_gpio(-1, ARRAY_SIZE(tl_wr842n_v3_leds_gpio),
+				 tl_wr842n_v3_leds_gpio);
+
+	ath79_register_gpio_keys_polled(1, TL_WR841NV9_KEYS_POLL_INTERVAL,
+					ARRAY_SIZE(tl_wr842n_v3_gpio_keys),
+					tl_wr842n_v3_gpio_keys);
+
+	ath79_register_usb();
+}
+
+MIPS_MACHINE(ATH79_MACH_TL_WR842N_V3, "TL-WR842N-v3", "TP-LINK TL-WR842N/ND v3",
+	     tl_wr842n_v3_setup);
 
 static void __init tl_wr841n_v11_setup(void)
 {

--- a/target/linux/ar71xx/image/Makefile
+++ b/target/linux/ar71xx/image/Makefile
@@ -590,6 +590,13 @@ define Device/tl-wr842n-v2
     TPLINK_HWID := 0x8420002
 endef
 
+define Device/tl-wr842n-v3
+    $(Device/tplink-16mlzma)
+    BOARDNAME := TL-WR842N-v3
+    DEVICE_PROFILE := TLWR842
+    TPLINK_HWID := 0x08420003
+endef
+
 define Device/tl-wr843nd-v1
     $(Device/tplink-4mlzma)
     BOARDNAME := TL-WR841N-v8
@@ -603,7 +610,7 @@ define Device/tl-wr847n-v8
     DEVICE_PROFILE := TLWR841
     TPLINK_HWID := 0x08470008
 endef
-TARGET_DEVICES += tl-wr841n-v8 tl-wr841n-v9 tl-wr841n-v10 tl-wr841n-v11 tl-wr842n-v2 tl-wr843nd-v1 tl-wr847n-v8
+TARGET_DEVICES += tl-wr841n-v8 tl-wr841n-v9 tl-wr841n-v10 tl-wr841n-v11 tl-wr842n-v2 tl-wr842n-v3 tl-wr843nd-v1 tl-wr847n-v8
 
 define Device/tl-wr941nd-v5
     $(Device/tplink-4mlzma)

--- a/target/linux/ar71xx/patches-3.18/610-MIPS-ath79-openwrt-machines.patch
+++ b/target/linux/ar71xx/patches-3.18/610-MIPS-ath79-openwrt-machines.patch
@@ -1,6 +1,6 @@
 --- a/arch/mips/ath79/machtypes.h
 +++ b/arch/mips/ath79/machtypes.h
-@@ -16,22 +16,201 @@
+@@ -16,22 +16,202 @@
  
  enum ath79_mach_type {
  	ATH79_MACH_GENERIC = 0,
@@ -148,6 +148,7 @@
 +	ATH79_MACH_TL_WR841N_V9,	/* TP-LINK TL-WR841N/ND v9 */
 +	ATH79_MACH_TL_WR841N_V11,	/* TP-LINK TL-WR841N/ND v11 */
 +	ATH79_MACH_TL_WR842N_V2,	/* TP-LINK TL-WR842N/ND v2 */
++	ATH79_MACH_TL_WR842N_V3,	/* TP-LINK TL-WR842N/ND v3 */
 +	ATH79_MACH_TL_WR941ND,		/* TP-LINK TL-WR941ND */
 +	ATH79_MACH_TL_WR941ND_V5,	/* TP-LINK TL-WR941ND v5 */
 +	ATH79_MACH_TL_WR941ND_V6,	/* TP-LINK TL-WR941ND v6 */
@@ -284,7 +285,7 @@
  config ATH79_MACH_AP121
  	bool "Atheros AP121 reference board"
  	select SOC_AR933X
-@@ -11,62 +84,1061 @@ config ATH79_MACH_AP121
+@@ -11,62 +84,1062 @@ config ATH79_MACH_AP121
  	select ATH79_DEV_M25P80
  	select ATH79_DEV_USB
  	select ATH79_DEV_WMAC
@@ -1252,13 +1253,14 @@
 +	select ATH79_DEV_WMAC
 +
 +config ATH79_MACH_TL_WR841N_V9
-+       bool "TP-LINK TL-WR841N/ND v9 support"
-+       select SOC_QCA953X
-+       select ATH79_DEV_ETH
-+       select ATH79_DEV_GPIO_BUTTONS
-+       select ATH79_DEV_LEDS_GPIO
-+       select ATH79_DEV_M25P80
-+       select ATH79_DEV_WMAC
++	bool "TP-LINK TL-WR841N/ND v9/TL-WR842N/ND v3 support"
++	select SOC_QCA953X
++	select ATH79_DEV_ETH
++	select ATH79_DEV_GPIO_BUTTONS
++	select ATH79_DEV_LEDS_GPIO
++	select ATH79_DEV_M25P80
++	select ATH79_DEV_USB
++	select ATH79_DEV_WMAC
 +
 +config ATH79_MACH_TL_WR941ND
 +	bool "TP-LINK TL-WR941ND support"
@@ -1374,7 +1376,7 @@
  
  config ATH79_MACH_UBNT_XM
  	bool "Ubiquiti Networks XM/UniFi boards"
-@@ -83,6 +1155,106 @@ config ATH79_MACH_UBNT_XM
+@@ -83,6 +1156,106 @@ config ATH79_MACH_UBNT_XM
  	  Say 'Y' here if you want your kernel to support the
  	  Ubiquiti Networks XM (rev 1.0) board.
  
@@ -1481,7 +1483,7 @@
  endmenu
  
  config SOC_AR71XX
-@@ -124,7 +1296,10 @@ config ATH79_DEV_DSA
+@@ -124,7 +1297,10 @@ config ATH79_DEV_DSA
  config ATH79_DEV_ETH
  	def_bool n
  
@@ -1493,7 +1495,7 @@
  	def_bool n
  
  config ATH79_DEV_GPIO_BUTTONS
-@@ -154,6 +1329,11 @@ config ATH79_PCI_ATH9K_FIXUP
+@@ -154,6 +1330,11 @@ config ATH79_PCI_ATH9K_FIXUP
  	def_bool n
  
  config ATH79_ROUTERBOOT


### PR DESCRIPTION
This patch adds support for TP-LINK TL-WR842N/ND v3 to OpenWrt Chaos Calmer 15.05.

- CPU QCA9531-BL3A
- RAM: 64MB
- flash: 16MB
- USB

AP143 platform, similar to tl-wr841n v10/v11, but with USB

Signed-off-by: Cezary Jackiewicz <cezary@eko.one.pl>