### PR TITLE
include/prereq-build.mk: Fix bad test for git version

### DIFF
--- a/include/prereq-build.mk
+++ b/include/prereq-build.mk
@@ -145,7 +145,7 @@ $(eval $(call SetupHostCommand,svn,Please install the Subversion client, \
 	svn --version | grep Subversion))
 
 $(eval $(call SetupHostCommand,git,Please install Git (git-core) >= 1.6.5, \
-	git clone 2>&1 | grep -- --recursive))
+	git clone 2>&1 | grep -- --recur))
 
 $(eval $(call SetupHostCommand,file,Please install the 'file' package, \
 	file --version 2>&1 | grep file))


### PR DESCRIPTION
The current test for the git version is broken because it depends upon
something really stupid: the output of --help.  This patch causes it to
work with a recent version of git, although using the same stupid
mechanism that can break again with a future git release.