### PR TITLE
tools/automake: Cherry pick from LEDE to fix bad regex -- open bracke…

### DIFF
--- a/tools/automake/Makefile
+++ b/tools/automake/Makefile
@@ -7,11 +7,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=automake
-PKG_VERSION:=1.15
+PKG_CPE_ID:=cpe:/a:gnu:automake
+PKG_VERSION:=1.15.1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@GNU/automake
-PKG_MD5SUM:=9a1ddb0e053474d9d1105cfe39b0c48d
+PKG_HASH:=af6ba39142220687c500f79b4aa2f181d9b24e4f8d8ec497cea4ba26c64bedaf
 
 include $(INCLUDE_DIR)/host-build.mk
 
@@ -24,7 +25,7 @@ HOST_CONFIGURE_VARS += \
 	am_cv_prog_PERL_ithreads=no
 
 define Host/Configure
-	(cd $(HOST_BUILD_DIR); $(AM_TOOL_PATHS) STAGING_DIR="" ./bootstrap.sh)
+	(cd $(HOST_BUILD_DIR); $(AM_TOOL_PATHS) STAGING_DIR="" ./bootstrap)
 	$(call Host/Configure/Default)
 endef
 

--- a/tools/automake/patches/000-relocatable.patch
+++ b/tools/automake/patches/000-relocatable.patch
@@ -24,7 +24,7 @@
 +
  # aclocal - create aclocal.m4 by scanning configure.ac
  
- # Copyright (C) 1996-2014 Free Software Foundation, Inc.
+ # Copyright (C) 1996-2017 Free Software Foundation, Inc.
 @@ -27,7 +29,7 @@ eval 'case $# in 0) exec @PERL@ -S "$0";
  
  BEGIN
@@ -59,7 +59,7 @@
 +$^W = 1;
 +
  # automake - create Makefile.in from Makefile.am
- # Copyright (C) 1994-2014 Free Software Foundation, Inc.
+ # Copyright (C) 1994-2017 Free Software Foundation, Inc.
  
 @@ -31,7 +33,7 @@ use strict;
  
@@ -79,7 +79,7 @@
  
 +$^W = 1;
 +
- # Copyright (C) 2012-2014 Free Software Foundation, Inc.
+ # Copyright (C) 2012-2017 Free Software Foundation, Inc.
  
  # This program is free software; you can redistribute it and/or modify
 --- a/t/wrap/automake.in
@@ -91,6 +91,6 @@
  
 +$^W = 1;
 +
- # Copyright (C) 2012-2014 Free Software Foundation, Inc.
+ # Copyright (C) 2012-2017 Free Software Foundation, Inc.
  
  # This program is free software; you can redistribute it and/or modify


### PR DESCRIPTION
…t not escaped

The current build is broken due to a bad regex that for some reason
wasn't blowing up before.