### PR TITLE
Fix uClibc implicit function declarations

### DIFF
--- a/toolchain/uClibc/patches-0.9.33.2/620-fix-__libc_longjmp-undeclared.patch
+++ b/toolchain/uClibc/patches-0.9.33.2/620-fix-__libc_longjmp-undeclared.patch
@@ -1,0 +1,13 @@
+diff --git b/libpthread/nptl/sysdeps/pthread/pt-longjmp.c a/libpthread/nptl/sysdeps/pthread/pt-longjmp.c
+index f161380..fb0628d 100644
+--- b/libpthread/nptl/sysdeps/pthread/pt-longjmp.c
++++ a/libpthread/nptl/sysdeps/pthread/pt-longjmp.c
+@@ -21,6 +21,8 @@
+ #include <stdlib.h>
+ #include "pthreadP.h"
+ 
++extern __typeof(longjmp) __libc_longjmp attribute_noreturn;
++
+ void
+ longjmp (jmp_buf env, int val)
+ {

--- a/toolchain/uClibc/patches-0.9.33.2/621-fix-undefined-TLS_DTPREL_VALUE.patch
+++ b/toolchain/uClibc/patches-0.9.33.2/621-fix-undefined-TLS_DTPREL_VALUE.patch
@@ -1,0 +1,31 @@
+diff --git a/ldso/include/ldso.h b/ldso/include/ldso.h
+index 6f3b728..e72d9da 100644
+--- a/ldso/include/ldso.h
++++ b/ldso/include/ldso.h
+@@ -48,6 +48,7 @@
+ #ifdef __UCLIBC_HAS_TLS__
+ /* Defines USE_TLS */
+ #include <tls.h>
++#include <dl-tls.h>
+ #endif
+ #include <dl-hash.h>
+ 
+diff --git a/libpthread/nptl/sysdeps/mips/dl-tls.h b/libpthread/nptl/sysdeps/mips/dl-tls.h
+index 3ad3b2b..fbc2c8e 100644
+--- a/libpthread/nptl/sysdeps/mips/dl-tls.h
++++ b/libpthread/nptl/sysdeps/mips/dl-tls.h
+@@ -17,6 +17,8 @@
+    Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+    02111-1307 USA.  */
+ 
++#ifndef _DL_TLS_H
++#define _DL_TLS_H	1
+ 
+ /* Type used for the representation of TLS information in the GOT.  */
+ typedef struct
+@@ -44,3 +46,5 @@ extern void *__tls_get_addr (tls_index *ti);
+ 
+ # define GET_ADDR_OFFSET	(ti->ti_offset + TLS_DTV_OFFSET)
+ # define __TLS_GET_ADDR(__ti)	(__tls_get_addr (__ti) - TLS_DTV_OFFSET)
++
++#endif	/* dl-tls.h */


### PR DESCRIPTION
-Werror=implicit-function-declaration and -Werror=implicit-int are your
friends. :) If it isn't declared, it shouldn't build.  This patch fixes
build breakages with the above warnings as errors.