### PR TITLE
Now recognizes git 2.17 (on Ubuntu 18.04)

### DIFF
--- a/include/prereq-build.mk
+++ b/include/prereq-build.mk
@@ -145,7 +145,7 @@ $(eval $(call SetupHostCommand,svn,Please install the Subversion client, \
 	svn --version | grep Subversion))
 
 $(eval $(call SetupHostCommand,git,Please install Git (git-core) >= 1.6.5, \
-	git clone 2>&1 | grep -- --recursive))
+	git clone 2>&1 | grep -- --recurs))
 
 $(eval $(call SetupHostCommand,file,Please install the 'file' package, \
 	file --version 2>&1 | grep file))


### PR DESCRIPTION
The `git` command on Ubuntu 18.04 (version 2.17) has a `--recurse-submodules` option but no `--recursive` options, causing `make menuconfig` to fail with:

    Build dependency: Please install Git (git-core) >= 1.6.5
